### PR TITLE
替换 BabelStone Blog 链接

### DIFF
--- a/gooreplacer.gson
+++ b/gooreplacer.gson
@@ -37,10 +37,10 @@
             "kind": "wildcard",
             "enable": true
         },
-        "apis.google.com/js/plusone.js": {
-            "dstURL": "cdn.rawgit.com/jiacai2050/gooreplacer/gh-pages/proxy/plusone.js",
+        "babelstone.blogspot.com": {
+            "dstURL": "babelstone.co.uk/Blog",
             "kind": "wildcard",
             "enable": true
-        }
+        },
     }
 }


### PR DESCRIPTION
BabelStone 网站的博客设在 babelstone.blogspot.com，但有个镜像设在自己网站服务器上，这个规则可以让任何链接到他博客的链接都能重定向到他的镜像。测试点：
http://www.babelstone.co.uk/Fonts/Marchen.html