### PR TITLE
更新 gooreplacer.gson 规则

### DIFF
--- a/gooreplacer.gson
+++ b/gooreplacer.gson
@@ -7,6 +7,11 @@
             "kind": "wildcard",
             "enable": true
         },
+        "fonts.googleapis.com": {
+            "dstURL": "fonts.proxy.ustclug.org",
+            "kind": "wildcard",
+            "enable": false
+        }
         "storage.googleapis.com": {
             "dstURL": "storage-googleapis.proxy.ustclug.org",
             "kind": "wildcard",
@@ -22,18 +27,23 @@
             "kind": "wildcard",
             "enable": true
         },
+        "fonts.gstatic.com": {
+            "dstURL": "fonts-gstatic.proxy.ustclug.org",
+            "kind": "wildcard",
+            "enable": false
+        }
         "platform.twitter.com/widgets.js": {
-            "dstURL": "cdn.rawgit.com/jiacai2050/gooreplacer/gh-pages/proxy/widgets.js",
+            "dstURL": "cdn.jsdelivr.net/gh/jiacai2050/gooreplacer@gh-pages/proxy/widgets.js",
             "kind": "wildcard",
             "enable": true
         },
         "apis.google.com/js/api.js": {
-            "dstURL": "cdn.rawgit.com/jiacai2050/gooreplacer/gh-pages/proxy/api.js",
+            "dstURL": "cdn.jsdelivr.net/gh/jiacai2050/gooreplacer@gh-pages/proxy/api.js",
             "kind": "wildcard",
             "enable": true
         },
         "apis.google.com/js/plusone.js": {
-            "dstURL": "cdn.rawgit.com/jiacai2050/gooreplacer/gh-pages/proxy/plusone.js",
+            "dstURL": "cdn.jsdelivr.net/gh/jiacai2050/gooreplacer@gh-pages/proxy/plusone.js",
             "kind": "wildcard",
             "enable": true
         }


### PR DESCRIPTION
将 RawGit 镜像资源替换成 jsDelivr 镜像。
另外，由于 V2EX 上还有人抱怨谷歌字体服务有异常情况（[[1]](https://www.v2ex.com/t/449033#reply11) [[2]](https://www.v2ex.com/t/459726) [[3]](https://www.v2ex.com/t/470075)），所以在这里补上，一出问题就可以直接开启。

close https://github.com/jiacai2050/gooreplacer/issues/65